### PR TITLE
Set CI to run "push" only on main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Running both "push" and "pull_request" for every PR is completely unnecessary. They perform the same work.