### PR TITLE
refactor: Stop using default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ TypeScript typings are available directly as part of the package.
 You can call the fetcher as follows:
 
 ```js
-const fetchMensa = require('ka-mensa-fetch')
+import { fetchMensa } from 'ka-mensa-fetch'
 
 const promise = fetchMensa(options)
 promise.then(plans => console.log(plans))
@@ -53,7 +53,7 @@ promise.then(plans => console.log(plans))
 or in an async context:
 
 ```js
-const fetchMensa = require('ka-mensa-fetch')
+import { fetchMensa } from 'ka-mensa-fetch'
 
 ;(async () => {
   const plans = await fetchMensa(options)
@@ -239,7 +239,7 @@ a session cookie first and providing it with future requests. This is
 implemented in `ka-mensa-fetch`, to be used as follows:
 
 ```js
-const fetchMensa = require('ka-mensa-fetch')
+import { fetchMensa } from 'ka-mensa-fetch'
 
 ;(async () => {
   const session = await fetchMensa.requestSessionCookie()
@@ -279,7 +279,8 @@ also has an id and a display name.
   <summary>Code example</summary>
 
 ```js
-const canteens = require('ka-mensa-fetch/data/canteens.json')
+// need to enable JSON imports in TypeScript config
+import canteens from 'ka-mensa-fetch/data/canteens.json'
 console.log(canteens)
 ```
 
@@ -310,7 +311,8 @@ A list of meal qualifiers / additives / warnings / etc.
   <summary>Code example</summary>
 
 ```js
-const legend = require('ka-mensa-fetch/data/legend.json')
+// need to enable JSON imports in TypeScript config
+import legend from 'ka-mensa-fetch/data/legend.json'
 console.log(legend)
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
-import fetchSimpleSite from './src/simplesite'
-import fetchJSON from './src/jsonapi'
-import requestSessionCookie from './src/cookies/request-session-cookie'
+import { fetch as fetchSimpleSite } from './src/simplesite'
+import { fetch as fetchJson } from './src/jsonapi'
 import { JsonApiOptions, Options, SimpleSiteOptions } from './src/types/options'
 import { CanteenPlan } from './src/types/canteen-plan'
 
@@ -45,7 +44,7 @@ function resolveSource (options?: Options): 'simplesite' | 'jsonapi' | undefined
  * @param {?object} options The fetcher options.
  * @returns {Promise<object[]>} Resolves to a set of meal plans.
  */
-async function fetch (options?: Options): Promise<CanteenPlan[]> {
+export async function fetchMensa (options?: Options): Promise<CanteenPlan[]> {
   const source = resolveSource(options)
   if (source == null) {
     throw new Error('options.source invalid')
@@ -60,10 +59,9 @@ async function fetch (options?: Options): Promise<CanteenPlan[]> {
     case 'simplesite':
       return fetchSimpleSite(mergedOptions as SimpleSiteOptions)
     case 'jsonapi':
-      return fetchJSON(mergedOptions as JsonApiOptions)
+      return fetchJson(mergedOptions as JsonApiOptions)
   }
 }
 
-fetch.requestSessionCookie = requestSessionCookie
-
-export = fetch
+// re-export session cookie function
+export { requestSessionCookie } from './src/cookies/request-session-cookie'

--- a/src/cookies/request-session-cookie.ts
+++ b/src/cookies/request-session-cookie.ts
@@ -72,7 +72,7 @@ function findCookie (headers?: Headers): string | undefined {
  *
  * @returns {Promise<string|undefined>} Resolves to the session cookie, or undefined on failure.
  */
-export default async function requestSessionCookie (): Promise<string | undefined> {
+export async function requestSessionCookie (): Promise<string | undefined> {
   const response = await axios.get(SITE_URL, {
     headers: {
       'User-Agent': USER_AGENT

--- a/src/jsonapi/build-canteen-lookup.ts
+++ b/src/jsonapi/build-canteen-lookup.ts
@@ -86,7 +86,7 @@ function mergeLine (first: Line, second?: Line): Line {
  * @param {?(object[])} extend The overriding canteen data.
  * @returns {Map} The lookup table.
  */
-export default function buildCanteenLookup (base: Canteen[], extend?: Canteen[]): Map<string, MappedCanteen> {
+export function buildCanteenLookup (base: Canteen[], extend?: Canteen[]): Map<string, MappedCanteen> {
   const baseMap = toCanteenMap(base)
   if (extend == null) return baseMap
   const extendMap = toCanteenMap(extend)

--- a/src/jsonapi/index.ts
+++ b/src/jsonapi/index.ts
@@ -1,6 +1,6 @@
-import request, { METADATA_ENDPOINT, PLANS_ENDPOINT } from './jsonapi-request'
-import parseMetadata from './jsonapi-parse-metadata'
-import parsePlans from './jsonapi-parse-plans'
+import { request, METADATA_ENDPOINT, PLANS_ENDPOINT } from './jsonapi-request'
+import { parseMetadata } from './jsonapi-parse-metadata'
+import { parsePlans } from './jsonapi-parse-plans'
 import { JsonApiOptions } from '../types/options'
 import { CanteenPlan } from '../types/canteen-plan'
 
@@ -14,7 +14,7 @@ import { CanteenPlan } from '../types/canteen-plan'
  * @param {object} options The fetcher options.
  * @returns {Promise<object[]>} Parsed results.
  */
-export default async function fetch (options: JsonApiOptions): Promise<CanteenPlan[]> {
+export async function fetch (options: JsonApiOptions): Promise<CanteenPlan[]> {
   const auth = options?.auth
   if (auth == null) {
     throw new Error('auth option is required')

--- a/src/jsonapi/jsonapi-parse-metadata.ts
+++ b/src/jsonapi/jsonapi-parse-metadata.ts
@@ -21,7 +21,7 @@ export interface UnparsedMetadata {
  * @param {object} json The JSON general data to parse.
  * @returns {object[]} The parse results.
  */
-export default function parseMetadata (json: UnparsedMetadata): Canteen[] {
+export function parseMetadata (json: UnparsedMetadata): Canteen[] {
   const canteens: Canteen[] = []
 
   if (json.mensa == null) return canteens

--- a/src/jsonapi/jsonapi-parse-plans.ts
+++ b/src/jsonapi/jsonapi-parse-plans.ts
@@ -1,8 +1,8 @@
 import moment from 'moment'
 
 import canteens from '../../data/canteens.json'
-import buildCanteenLookup, { MappedCanteen } from './build-canteen-lookup'
-import DateSpec from '../types/date-spec'
+import { buildCanteenLookup, MappedCanteen } from './build-canteen-lookup'
+import { DateSpec } from '../types/date-spec'
 import { CanteenPlan, CanteenLine, CanteenMeal } from '../types/canteen-plan'
 import { Canteen } from '../types/canteen'
 
@@ -191,7 +191,7 @@ function parseLines (canteen: MappedCanteen, lineMapping: any): CanteenLine[] {
  * @param {?(object[])} metadata A supplementary 'canteens.json'-like structure.
  * @returns {object[]} The parse results.
  */
-export default function parsePlans (json: any, referenceDate: Date, metadata?: Canteen[]): CanteenPlan[] {
+export function parsePlans (json: any, referenceDate: Date, metadata?: Canteen[]): CanteenPlan[] {
   const lookup: Map<string, MappedCanteen> = buildCanteenLookup(canteens, metadata)
 
   // the JSON is structured as follows:

--- a/src/jsonapi/jsonapi-request.ts
+++ b/src/jsonapi/jsonapi-request.ts
@@ -41,7 +41,7 @@ const REQUEST_MAX_LENGTH = 1024 * 1024 // 1 MiB
  * @param {string} endpoint The endpoint (METADATA_ENDPOINT, PLANS_ENDPOINT).
  * @returns {Promise<object>} Resolves to JSON object on success.
  */
-export default async function request (auth: AuthConfig, endpoint: string): Promise<object> {
+export async function request (auth: AuthConfig, endpoint: string): Promise<object> {
   if (endpoint !== METADATA_ENDPOINT && endpoint !== PLANS_ENDPOINT) {
     throw new Error('invalid endpoint specified')
   }

--- a/src/simplesite/index.ts
+++ b/src/simplesite/index.ts
@@ -1,6 +1,6 @@
 import canteens from '../../data/canteens.json'
-import request from './simplesite-request'
-import parse from './simplesite-parse'
+import { request } from './simplesite-request'
+import { parse } from './simplesite-parse'
 import { getCurrentWeek, isDateSupported, convertToWeeks } from './simplesite-date-util'
 import { CanteenPlan } from '../types/canteen-plan'
 import { SimpleSiteOptions } from '../types/options'
@@ -45,7 +45,7 @@ async function fetchSingle (canteenId: string, weekId: string | number, sessionC
  * @param {?object} options The fetcher options.
  * @returns {Promise<object[]>} Parsed results.
  */
-export default async function fetch (options: SimpleSiteOptions): Promise<CanteenPlan[]> {
+export async function fetch (options: SimpleSiteOptions): Promise<CanteenPlan[]> {
   const ids = options.canteens ?? CANTEEN_IDS
   const weeks = options.dates != null
     ? convertToWeeks(options.dates.filter(isDateSupported))

--- a/src/simplesite/match-line-name.ts
+++ b/src/simplesite/match-line-name.ts
@@ -34,7 +34,7 @@ const LINE_IDS_MAPPING: Map<string, Map<string, string>> = (() => {
  * @param {string} name The human-readable line name.
  * @returns {?string} The line id.
  */
-export default function matchLineName (canteenId: string, name: string): string | undefined {
+export function matchLineName (canteenId: string, name: string): string | undefined {
   // sanity check canteenId
   const lineNameToIdMap = LINE_IDS_MAPPING.get(canteenId)
   if (lineNameToIdMap == null) {

--- a/src/simplesite/parse-classifiers.ts
+++ b/src/simplesite/parse-classifiers.ts
@@ -17,7 +17,7 @@ const CLASSIFIERS_REGEXP = /^\s*\[([\w,]+)\]\s*$/
  * @param {string} str The classifiers string.
  * @returns {string[]} The classifiers array.
  */
-export default function parseClassifiers (str: string): string[] {
+export function parseClassifiers (str: string): string[] {
   const match = str.match(CLASSIFIERS_REGEXP)
   if (match != null) {
     return match[1].split(/\s*,\s*/)

--- a/src/simplesite/parse-datestamp.ts
+++ b/src/simplesite/parse-datestamp.ts
@@ -1,4 +1,4 @@
-import DateSpec from '../types/date-spec'
+import { DateSpec } from '../types/date-spec'
 
 // CONSTANTS
 
@@ -51,7 +51,7 @@ function guessYear (refYear: number, refMonth: number, month: number): number {
  * @param {Date} reference The reference date for year guessing.
  * @returns {?object} An object containing integers: day, month, year.
  */
-export default function parseDatestamp (str: string, reference: Date): DateSpec | undefined {
+export function parseDatestamp (str: string, reference: Date): DateSpec | undefined {
   const match = str.match(DATE_REGEXP)
   if (match == null) {
     return undefined

--- a/src/simplesite/parse-name-and-additives.ts
+++ b/src/simplesite/parse-name-and-additives.ts
@@ -1,4 +1,4 @@
-import mergeWhitespace from '../util/merge-whitespace'
+import { mergeWhitespace } from '../util/merge-whitespace'
 
 // CONSTANTS
 
@@ -24,7 +24,7 @@ const NAME_ADDITIVES_REGEXP = /^\s*([\s\S]+\S)\s+\(\s*(\w{1,3}(?:\s*,\s*\w{1,3})
  * @param {string} str The string to parse.
  * @returns {object} The resulting name,additives object.
  */
-export default function parseNameAndAdditives (str: string): { name: string, additives: string[] } {
+export function parseNameAndAdditives (str: string): { name: string, additives: string[] } {
   const match = str.match(NAME_ADDITIVES_REGEXP)
   if (match != null) {
     return {

--- a/src/simplesite/simplesite-date-util.ts
+++ b/src/simplesite/simplesite-date-util.ts
@@ -1,5 +1,5 @@
 import moment, { Moment } from 'moment'
-import DateSpec from '../types/date-spec'
+import { DateSpec } from '../types/date-spec'
 
 // TYPES
 

--- a/src/simplesite/simplesite-parse.ts
+++ b/src/simplesite/simplesite-parse.ts
@@ -1,12 +1,12 @@
 import cheerio, { Cheerio, CheerioAPI, Element } from 'cheerio'
 
-import mergeWhitespace from '../util/merge-whitespace'
+import { mergeWhitespace } from '../util/merge-whitespace'
 
-import parseDatestamp from './parse-datestamp'
-import parseClassifiers from './parse-classifiers'
-import parseNameAndAdditives from './parse-name-and-additives'
+import { parseDatestamp } from './parse-datestamp'
+import { parseClassifiers } from './parse-classifiers'
+import { parseNameAndAdditives } from './parse-name-and-additives'
 
-import matchLineName from './match-line-name'
+import { matchLineName } from './match-line-name'
 import { CanteenLine, CanteenMeal, CanteenPlan } from '../types/canteen-plan'
 
 // METHODS
@@ -127,7 +127,7 @@ function parseMeal ($: CheerioAPI, $row: Cheerio<Element>): CanteenMeal | undefi
  * @param {Date} referenceDate The date of plan acquisition, for reference.
  * @returns {object[]} The parse results.
  */
-export default function parse (html: string, canteenId: string, referenceDate: Date): CanteenPlan[] {
+export function parse (html: string, canteenId: string, referenceDate: Date): CanteenPlan[] {
   const $ = cheerio.load(html)
   const $titles = $('#platocontent > h1')
 

--- a/src/simplesite/simplesite-request.ts
+++ b/src/simplesite/simplesite-request.ts
@@ -33,7 +33,7 @@ const REQUEST_MAX_LENGTH = 1024 * 1024 // 1 MiB
  * @param {?string} sessionCookie Value of the session cookie.
  * @returns {Promise<string>} Resolves to HTML code on success (unprocessed).
  */
-export default async function request (canteenId: string, weekId: string | number, sessionCookie?: string): Promise<string> {
+export async function request (canteenId: string, weekId: string | number, sessionCookie?: string): Promise<string> {
   const headers = {
     Cookie: sessionCookie != null && sessionCookie !== '' ? `platoCMS=${sessionCookie}` : undefined
   }

--- a/src/types/canteen-plan.ts
+++ b/src/types/canteen-plan.ts
@@ -1,4 +1,4 @@
-import DateSpec from './date-spec'
+import { DateSpec } from './date-spec'
 
 /**
  * An object containing data about a specific meal.

--- a/src/types/date-spec.ts
+++ b/src/types/date-spec.ts
@@ -1,7 +1,7 @@
 /**
  * Standard date specification used in this library.
  */
-export default interface DateSpec {
+export interface DateSpec {
   year: number
   month: number
   day: number

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import DateSpec from './date-spec'
+import { DateSpec } from './date-spec'
 
 /**
  * Fetcher options object. Depending on the value of source, additional options might be available.

--- a/src/util/merge-whitespace.ts
+++ b/src/util/merge-whitespace.ts
@@ -7,6 +7,6 @@
  * @param {string} str Subject string.
  * @returns {string} The string with all whitespaces merged.
  */
-export default function mergeWhitespace (str: string): string {
+export function mergeWhitespace (str: string): string {
   return str.replace(/\s+/g, ' ')
 }

--- a/test/cookies/request-session-cookie.test.ts
+++ b/test/cookies/request-session-cookie.test.ts
@@ -1,5 +1,5 @@
-import requestSessionCookie from '../../src/cookies/request-session-cookie'
-import LazyMockAdapter from '../helper-lazymockadapter'
+import { requestSessionCookie } from '../../src/cookies/request-session-cookie'
+import { LazyMockAdapter } from '../helper-lazymockadapter'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/data/canteens.test.ts
+++ b/test/data/canteens.test.ts
@@ -1,6 +1,6 @@
 import canteens from '../../data/canteens.json'
-import isTrimmed from '../helper-is-trimmed'
-import checkDuplicates from '../helper-check-duplicates'
+import { isTrimmed } from '../helper-is-trimmed'
+import { checkDuplicates } from '../helper-check-duplicates'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/data/legend.test.ts
+++ b/test/data/legend.test.ts
@@ -1,6 +1,6 @@
 import legend from '../../data/legend.json'
-import isTrimmed from '../helper-is-trimmed'
-import checkDuplicates from '../helper-check-duplicates'
+import { isTrimmed } from '../helper-is-trimmed'
+import { checkDuplicates } from '../helper-check-duplicates'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/helper-check-duplicates.ts
+++ b/test/helper-check-duplicates.ts
@@ -10,7 +10,7 @@ import ExpectStatic = Chai.ExpectStatic
  * @param {function} accessProp To-String-Converter for the iterable's entries.
  * @returns {void}
  */
-export default function checkDuplicates<T> (expect: ExpectStatic, iterable: Iterable<T>, accessProp: (item: T) => string): void {
+export function checkDuplicates<T> (expect: ExpectStatic, iterable: Iterable<T>, accessProp: (item: T) => string): void {
   const counts: Map<string, number> = new Map()
   for (const entry of iterable) {
     const prop = accessProp(entry)

--- a/test/helper-is-trimmed.ts
+++ b/test/helper-is-trimmed.ts
@@ -4,6 +4,6 @@
  * @param {string} s The string.
  * @returns {boolean} Whether the string is trimmed.
  */
-export default function isTrimmed (s: string): boolean {
+export function isTrimmed (s: string): boolean {
   return s.trim() === s
 }

--- a/test/helper-lazymockadapter.ts
+++ b/test/helper-lazymockadapter.ts
@@ -4,7 +4,7 @@ import MockAdapter from 'axios-mock-adapter'
  * This is used in some test files to obtain an Axios MockAdapter.
  * The advantage is that it auto-initializes lazily and is easy to clean up, de-duplicating code among tests.
  */
-export default class LazyMockAdapter {
+export class LazyMockAdapter {
   private mock: MockAdapter | undefined
 
   /**

--- a/test/jsonapi/build-canteen-lookup.test.ts
+++ b/test/jsonapi/build-canteen-lookup.test.ts
@@ -1,4 +1,4 @@
-import buildCanteenLookup from '../../src/jsonapi/build-canteen-lookup'
+import { buildCanteenLookup } from '../../src/jsonapi/build-canteen-lookup'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/jsonapi/jsonapi-parse-metadata.test.ts
+++ b/test/jsonapi/jsonapi-parse-metadata.test.ts
@@ -1,4 +1,4 @@
-import parse from '../../src/jsonapi/jsonapi-parse-metadata'
+import { parseMetadata } from '../../src/jsonapi/jsonapi-parse-metadata'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised)
 describe('jsonapi/jsonapi-parse-metadata', function () {
   it('can handle empty root', function () {
     const data = {}
-    const obj = parse(data)
+    const obj = parseMetadata(data)
     expect(obj).to.deep.equal([])
   })
 
@@ -15,7 +15,7 @@ describe('jsonapi/jsonapi-parse-metadata', function () {
     const data = {
       mensa: {}
     }
-    const obj = parse(data)
+    const obj = parseMetadata(data)
     expect(obj).to.deep.equal([])
   })
 
@@ -26,7 +26,7 @@ describe('jsonapi/jsonapi-parse-metadata', function () {
         moltke: { name: 'M' }
       }
     }
-    const obj = parse(data)
+    const obj = parseMetadata(data)
     expect(obj).to.deep.equal([
       { id: 'adenauerring', name: 'A', lines: [] },
       { id: 'moltke', name: 'M', lines: [] }
@@ -46,7 +46,7 @@ describe('jsonapi/jsonapi-parse-metadata', function () {
         }
       }
     }
-    const obj = parse(data)
+    const obj = parseMetadata(data)
     expect(obj).to.deep.equal([
       {
         id: 'adenauerring',

--- a/test/jsonapi/jsonapi-parse-plans.test.ts
+++ b/test/jsonapi/jsonapi-parse-plans.test.ts
@@ -1,4 +1,4 @@
-import parse from '../../src/jsonapi/jsonapi-parse-plans'
+import { parsePlans } from '../../src/jsonapi/jsonapi-parse-plans'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised)
 describe('jsonapi/jsonapi-parse-plans', function () {
   it('can handle empty plan', function () {
     const data = {}
-    const obj = parse(data, new Date(2020, 7, 11))
+    const obj = parsePlans(data, new Date(2020, 7, 11))
     expect(obj).to.deep.equal([])
   })
 
@@ -16,7 +16,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
       adenauerring: {},
       moltke: {}
     }
-    const obj = parse(data, new Date(2020, 7, 11))
+    const obj = parsePlans(data, new Date(2020, 7, 11))
     expect(obj).to.deep.equal([])
   })
 
@@ -29,7 +29,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines).to.deep.equal([
       {
@@ -53,7 +53,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].date).to.deep.equal({
       day: 11,
@@ -73,7 +73,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
       }
     }
     const metadata = [{ id: 'adenauerring', name: 'override', lines: [] }]
-    const obj = parse(data, new Date(2020, 7, 10), metadata)
+    const obj = parsePlans(data, new Date(2020, 7, 10), metadata)
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].id).to.equal('adenauerring')
     expect(obj[0].name).to.equal('override')
@@ -87,7 +87,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines[0].id).to.equal('l1')
@@ -107,7 +107,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
       name: 'Mensa Am Adenauerring',
       lines: [{ id: 'l1', name: 'override' }]
     }]
-    const obj = parse(data, new Date(2020, 7, 11), metadata)
+    const obj = parsePlans(data, new Date(2020, 7, 11), metadata)
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines[0].id).to.equal('l1')
@@ -143,12 +143,12 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     })
-    const obj1 = parse(makeData('foo bar', ''), new Date(2020, 7, 10))
+    const obj1 = parsePlans(makeData('foo bar', ''), new Date(2020, 7, 10))
     expect(obj1).to.be.an('array').with.lengthOf(1)
     expect(obj1[0].lines).to.be.an('array').with.lengthOf(1)
     expect(obj1[0].lines[0].meals).to.be.an('array').with.lengthOf(1)
     expect(obj1[0].lines[0].meals[0].name).to.equal('foo bar')
-    const obj2 = parse(makeData('foo bar', 'baz qux'), new Date(2020, 7, 10))
+    const obj2 = parsePlans(makeData('foo bar', 'baz qux'), new Date(2020, 7, 10))
     expect(obj2[0].lines[0].meals[0].name).to.equal('foo bar baz qux')
   })
 
@@ -182,9 +182,9 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     })
-    const obj1 = parse(makeData(1.73, ''), new Date(2020, 7, 10))
+    const obj1 = parsePlans(makeData(1.73, ''), new Date(2020, 7, 10))
     expect(obj1[0].lines[0].meals[0].price).to.equal('1,73 €')
-    const obj2 = parse(makeData(1.73, 'ab'), new Date(2020, 7, 10))
+    const obj2 = parsePlans(makeData(1.73, 'ab'), new Date(2020, 7, 10))
     expect(obj2[0].lines[0].meals[0].price).to.equal('(ab) 1,73 €')
   })
 
@@ -218,7 +218,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj[0].lines[0].meals[0].price).to.equal('')
   })
 
@@ -251,7 +251,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj[0].lines[0].meals[0].classifiers).to.have.members(['B', 'MV', 'VG'])
   })
 
@@ -284,7 +284,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 10))
+    const obj = parsePlans(data, new Date(2020, 7, 10))
     expect(obj[0].lines[0].meals[0].additives).to.have.members(['Ei', 'Fi'])
   })
 
@@ -305,7 +305,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 11))
+    const obj = parsePlans(data, new Date(2020, 7, 11))
     expect(obj).to.be.an('array').with.lengthOf(2)
     expect(obj[0].date).to.deep.equal({
       day: 11,
@@ -327,7 +327,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 11))
+    const obj = parsePlans(data, new Date(2020, 7, 11))
     expect(obj).to.deep.equal([])
   })
 
@@ -339,7 +339,7 @@ describe('jsonapi/jsonapi-parse-plans', function () {
         }
       }
     }
-    const obj = parse(data, new Date(2020, 7, 11))
+    const obj = parsePlans(data, new Date(2020, 7, 11))
     expect(obj).to.be.an('array').with.lengthOf(1)
     expect(obj[0].lines).to.deep.equal([])
   })

--- a/test/jsonapi/jsonapi-request.test.ts
+++ b/test/jsonapi/jsonapi-request.test.ts
@@ -1,5 +1,5 @@
-import request, { METADATA_ENDPOINT, PLANS_ENDPOINT } from '../../src/jsonapi/jsonapi-request'
-import LazyMockAdapter from '../helper-lazymockadapter'
+import { request, METADATA_ENDPOINT, PLANS_ENDPOINT } from '../../src/jsonapi/jsonapi-request'
+import { LazyMockAdapter } from '../helper-lazymockadapter'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/match-line-name.test.ts
+++ b/test/simplesite/match-line-name.test.ts
@@ -1,4 +1,4 @@
-import matchLineName from '../../src/simplesite/match-line-name'
+import { matchLineName } from '../../src/simplesite/match-line-name'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-classifiers.test.ts
+++ b/test/simplesite/parse-classifiers.test.ts
@@ -1,4 +1,4 @@
-import parseClassifiers from '../../src/simplesite/parse-classifiers'
+import { parseClassifiers } from '../../src/simplesite/parse-classifiers'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-datestamp.test.ts
+++ b/test/simplesite/parse-datestamp.test.ts
@@ -1,4 +1,4 @@
-import parseDatestamp from '../../src/simplesite/parse-datestamp'
+import { parseDatestamp } from '../../src/simplesite/parse-datestamp'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-name-and-additives.test.ts
+++ b/test/simplesite/parse-name-and-additives.test.ts
@@ -1,4 +1,4 @@
-import parseNameAndAdditives from '../../src/simplesite/parse-name-and-additives'
+import { parseNameAndAdditives } from '../../src/simplesite/parse-name-and-additives'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/simplesite-parse.test.ts
+++ b/test/simplesite/simplesite-parse.test.ts
@@ -1,4 +1,4 @@
-import parse from '../../src/simplesite/simplesite-parse'
+import { parse } from '../../src/simplesite/simplesite-parse'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/simplesite-request.test.ts
+++ b/test/simplesite/simplesite-request.test.ts
@@ -1,5 +1,5 @@
-import request from '../../src/simplesite/simplesite-request'
-import LazyMockAdapter from '../helper-lazymockadapter'
+import { request } from '../../src/simplesite/simplesite-request'
+import { LazyMockAdapter } from '../helper-lazymockadapter'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/util/merge-whitespace.test.ts
+++ b/test/util/merge-whitespace.test.ts
@@ -1,4 +1,4 @@
-import mergeWhitespace from '../../src/util/merge-whitespace'
+import { mergeWhitespace } from '../../src/util/merge-whitespace'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'


### PR DESCRIPTION
Default exports generally behave worse than regular named exports in TypeScript.
Hence, this PR eliminates default exports.

This also means that importing this library from a user perspective will change:

```js
import fetchMensa from 'ka-mensa-fetch'
```

becomes

```js
import { fetchMensa } from 'ka-mensa-fetch'
```