### PR TITLE
feat: Re-export important types

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,41 @@ Promise resolution value (shortened):
 </details>
 
 
+### TypeScript Types
+
+This library includes strong typing for its objects.
+The following types are available:
+
+```ts
+import {
+
+  // types as they appear in data/canteens.json
+  Line,
+  Canteen,
+
+  // types as they appear in data/legend.json
+  LegendItem,
+
+  // types as they appear in fetch results
+  // (plans contain lines, which contain meals)
+  CanteenPlan,
+  CanteenLine,
+  CanteenMeal,
+  
+  // these types are used whenever dates are needed
+  DateSpec,
+  datelike,
+  
+  // types used for specifying fetcher options
+  Options,
+  SimpleSiteOptions,
+  JsonApiOptions,
+  AuthConfig
+
+} from 'ka-mensa-fetch'
+```
+
+
 ### Caching
 
 Because `ka-mensa-fetch` accesses sources not meant for automated processing,

--- a/index.ts
+++ b/index.ts
@@ -71,3 +71,10 @@ export async function fetchMensa (source: 'simplesite' | 'jsonapi' = 'simplesite
 
 // re-export session cookie function
 export { requestSessionCookie } from './src/cookies/request-session-cookie'
+
+// re-export types
+export { Line, Canteen } from './src/types/canteen'
+export { LegendItem } from './src/types/legend'
+export { CanteenPlan, CanteenLine, CanteenMeal } from './src/types/canteen-plan'
+export { DateSpec, datelike } from './src/types/date-spec'
+export { Options, SimpleSiteOptions, JsonApiOptions, AuthConfig } from './src/types/options'

--- a/src/simplesite/simplesite-date-util.ts
+++ b/src/simplesite/simplesite-date-util.ts
@@ -1,9 +1,7 @@
-import moment, { Moment } from 'moment'
-import { DateSpec } from '../types/date-spec'
+import moment from 'moment'
+import { datelike } from '../types/date-spec'
 
 // TYPES
-
-type datelike = DateSpec | Date | string | number | Moment
 
 // EXPORTS
 

--- a/src/types/date-spec.ts
+++ b/src/types/date-spec.ts
@@ -6,3 +6,8 @@ export interface DateSpec {
   month: number
   day: number
 }
+
+/**
+ * Anything that could be converted to a {@link DateSpec}.
+ */
+export type datelike = DateSpec | Date | string | number

--- a/src/types/legend.ts
+++ b/src/types/legend.ts
@@ -1,0 +1,8 @@
+/**
+ * Description of a legend entry.
+ * This is as it occurs in legend.json.
+ */
+export interface LegendItem {
+  short: string
+  label: string
+}

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import { DateSpec } from './date-spec'
+import { datelike } from './date-spec'
 
 /**
  * Fetcher options object. Depending on the value of source, additional options might be available.
@@ -15,7 +15,7 @@ export interface Options {
  */
 export interface SimpleSiteOptions extends Options {
   canteens?: string[]
-  dates?: Array<DateSpec | Date | string | number>
+  dates?: datelike[]
   sessionCookie?: string
 }
 


### PR DESCRIPTION
Important types such as CanteenPlan are re-exported from the main module
so that they can be used by consumers of this library without having to
deep-require paths inside the 'src' directory.