### PR TITLE
feat(data): Switch "Cafeteria 11-14 Uhr" and "To-Go" variant

### DIFF
--- a/data/canteens.json
+++ b/data/canteens.json
@@ -74,14 +74,14 @@
         "name": "Cafeteria Heiße Theke",
         "alternativeNames": [
           "Cafeteria",
-          "Cafeteria 11-14 Uhr To-Go"
+          "Cafeteria 11-14 Uhr"
         ]
       },
       {
         "id": "nmtisch",
         "name": "Cafeteria ab 14:30",
         "alternativeNames": [
-          "Cafeteria 11-14 Uhr"
+          "Cafeteria 11-14 Uhr To-Go"
         ]
       },
       {

--- a/test/simplesite/match-line-name.test.ts
+++ b/test/simplesite/match-line-name.test.ts
@@ -34,7 +34,6 @@ describe('simplesite/match-line-name', function () {
   })
 
   it('matches alternative names', function () {
-    expect(matchLineName('adenauerring', 'Cafeteria')).to.equal('heisstheke')
-    expect(matchLineName('adenauerring', 'Cafeteria 11-14 Uhr')).to.equal('nmtisch')
+    expect(matchLineName('adenauerring', '[kœri]werk 11-14 Uhr')).to.equal('aktion')
   })
 })


### PR DESCRIPTION
Previously, "Cafeteria 11-14 Uhr" would be the label for "nmtisch".
Unfortunately, at 24th November 2021 this was changed to be the label
of "heisstheke", while "nmtisch" is now called
"Cafeteria 11-14 Uhr To-Go". It appears more sensible to represent the
status quo in bundled data instead of providing infinite backwards
compatibility with the name resolution.