### PR TITLE
chore: Limit renovate of devDependencies to weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "extends": [
     "config:js-lib"
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "extends": ["schedule:weekly"]
+    }
+  ]
 }


### PR DESCRIPTION
This is needed especially due to eslint-plugin-jsdoc, which makes a new release for every commit and gets very noisy.