### PR TITLE
feat(data): Move alt. name "Vegane Linie" to l2

### DIFF
--- a/data/canteens.json
+++ b/data/canteens.json
@@ -19,7 +19,8 @@
           "Linie 2 To-Go",
           "Linie 2 BOOK A MENSA",
           "Linie 2 Gut & Günstig",
-          "Linie 2 vegane Linie"
+          "Linie 2 vegane Linie",
+          "Vegane Linie"
         ]
       },
       {
@@ -47,7 +48,7 @@
         "name": "Schnitzelbar",
         "alternativeNames": [
           "Schnitzel-Burger-Bar",
-          "Vegane Linie"
+          "Schnitzel-/ Burgerbar"
         ]
       },
       {


### PR DESCRIPTION
This will invalidate previously collected data, which had to have
"Vegane Linie" match "schnitzelbar". Unfortunately it seems very
difficult at the moment to correctly match the same alt name to
different lines depending on context, so the best way forward seems to
be to just move "Vegane Linie" to l2, representing the current state.
Additionally, "schnitzelbar" receives another alias with slightly
different spelling.