### PR TITLE
feat: Convert everything to ESM

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,8 @@ parserOptions:
   project: './tsconfig.eslint.json'
 
 rules:
+  # this project requires .js extensions with imports because it is packaged as ESM:
+  import/extensions: [error, always]
   # require JSDoc on every standard location, and also on classes, interfaces and enums
   jsdoc/require-jsdoc: [ 'error', { contexts: [ 'ClassDeclaration', 'TSInterfaceDeclaration', 'TSEnumDeclaration' ] } ]
   jsdoc/require-param-type: off

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  loader: 'ts-node/esm'
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The entire project is written in JavaScript+TypeScript and is composed as follow
 
 Make sure Node and NPM are available on your system, then use
 `npm i ka-mensa-fetch` to install it into your project's dependencies.
+Please note that it is packaged as an ECMAScript module and is incompatible
+with CommonJS.
 
 TypeScript typings are available directly as part of the package.
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import { fetch as fetchSimpleSite } from './src/simplesite'
-import { fetch as fetchJson } from './src/jsonapi'
-import { JsonApiOptions, Options, SimpleSiteOptions } from './src/types/options'
-import { CanteenPlan } from './src/types/canteen-plan'
+import { fetch as fetchSimpleSite } from './src/simplesite/index.js'
+import { fetch as fetchJson } from './src/jsonapi/index.js'
+import { JsonApiOptions, Options, SimpleSiteOptions } from './src/types/options.js'
+import { CanteenPlan } from './src/types/canteen-plan.js'
 
 // HELPER FUNCTIONS
 
@@ -70,11 +70,11 @@ export async function fetchMensa (source: 'simplesite' | 'jsonapi' = 'simplesite
 }
 
 // re-export session cookie function
-export { requestSessionCookie } from './src/cookies/request-session-cookie'
+export { requestSessionCookie } from './src/cookies/request-session-cookie.js'
 
 // re-export types
-export { Line, Canteen } from './src/types/canteen'
-export { LegendItem } from './src/types/legend'
-export { CanteenPlan, CanteenLine, CanteenMeal } from './src/types/canteen-plan'
-export { DateSpec, datelike } from './src/types/date-spec'
-export { Options, SimpleSiteOptions, JsonApiOptions, AuthConfig } from './src/types/options'
+export { Line, Canteen } from './src/types/canteen.js'
+export { LegendItem } from './src/types/legend.js'
+export { CanteenPlan, CanteenLine, CanteenMeal } from './src/types/canteen-plan.js'
+export { DateSpec, datelike } from './src/types/date-spec.js'
+export { Options, SimpleSiteOptions, JsonApiOptions, AuthConfig } from './src/types/options.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "4.6.3"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ka-mensa-fetch",
   "version": "2.1.5",
   "description": "Karlsruhe (KIT) Mensa meal plan fetcher",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -36,7 +37,7 @@
   },
   "homepage": "https://github.com/meyfa/ka-mensa-fetch#readme",
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
     "@types/chai": "4.3.1",

--- a/setup-package.js
+++ b/setup-package.js
@@ -1,12 +1,13 @@
-'use strict'
-
 /*
  * This file is used as an additional build step before publishing,
  * to adapt the package.json to be suitable for publishing from './dist'.
  */
 
-const fs = require('fs')
-const path = require('path')
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const ORIGINAL_PACKAGE_JSON = path.join(__dirname, 'package.json')
 const DIST_PACKAGE_JSON = path.join(__dirname, 'dist', 'package.json')

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module'
+import { Canteen } from './types/canteen.js'
+import { LegendItem } from './types/legend.js'
+
+const classicRequire = createRequire(import.meta.url)
+
+export const canteens: Canteen[] = classicRequire('../data/canteens.json')
+export const legend: LegendItem[] = classicRequire('../data/legend.json')

--- a/src/jsonapi/build-canteen-lookup.ts
+++ b/src/jsonapi/build-canteen-lookup.ts
@@ -1,4 +1,4 @@
-import { Canteen, Line } from '../types/canteen'
+import { Canteen, Line } from '../types/canteen.js'
 
 // TYPES
 

--- a/src/jsonapi/index.ts
+++ b/src/jsonapi/index.ts
@@ -1,8 +1,8 @@
-import { METADATA_ENDPOINT, PLANS_ENDPOINT, request } from './jsonapi-request'
-import { parseMetadata } from './jsonapi-parse-metadata'
-import { parsePlans } from './jsonapi-parse-plans'
-import { JsonApiOptions } from '../types/options'
-import { CanteenPlan } from '../types/canteen-plan'
+import { METADATA_ENDPOINT, PLANS_ENDPOINT, request } from './jsonapi-request.js'
+import { parseMetadata } from './jsonapi-parse-metadata.js'
+import { parsePlans } from './jsonapi-parse-plans.js'
+import { JsonApiOptions } from '../types/options.js'
+import { CanteenPlan } from '../types/canteen-plan.js'
 
 /**
  * Fetch the JSON API plan and parse it.

--- a/src/jsonapi/jsonapi-parse-metadata.ts
+++ b/src/jsonapi/jsonapi-parse-metadata.ts
@@ -1,4 +1,4 @@
-import { Canteen, Line } from '../types/canteen'
+import { Canteen, Line } from '../types/canteen.js'
 
 /**
  * The structure that might be returned by the JSON API.

--- a/src/jsonapi/jsonapi-parse-plans.ts
+++ b/src/jsonapi/jsonapi-parse-plans.ts
@@ -1,10 +1,9 @@
 import moment from 'moment'
-
-import canteens from '../../data/canteens.json'
-import { buildCanteenLookup, MappedCanteen } from './build-canteen-lookup'
-import { DateSpec } from '../types/date-spec'
-import { CanteenLine, CanteenMeal, CanteenPlan } from '../types/canteen-plan'
-import { Canteen } from '../types/canteen'
+import { canteens } from '../data.js'
+import { buildCanteenLookup, MappedCanteen } from './build-canteen-lookup.js'
+import { DateSpec } from '../types/date-spec.js'
+import { CanteenLine, CanteenMeal, CanteenPlan } from '../types/canteen-plan.js'
+import { Canteen } from '../types/canteen.js'
 
 // CONSTANTS
 

--- a/src/jsonapi/jsonapi-request.ts
+++ b/src/jsonapi/jsonapi-request.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
-
-import { AuthConfig } from '../types/options'
+import { AuthConfig } from '../types/options.js'
 
 // CONSTANTS
 

--- a/src/simplesite/index.ts
+++ b/src/simplesite/index.ts
@@ -1,9 +1,9 @@
-import canteens from '../../data/canteens.json'
-import { request } from './simplesite-request'
-import { parse } from './simplesite-parse'
-import { convertToWeeks, getCurrentWeek, isDateSupported } from './simplesite-date-util'
-import { CanteenPlan } from '../types/canteen-plan'
-import { SimpleSiteOptions } from '../types/options'
+import { canteens } from '../data.js'
+import { request } from './simplesite-request.js'
+import { parse } from './simplesite-parse.js'
+import { convertToWeeks, getCurrentWeek, isDateSupported } from './simplesite-date-util.js'
+import { CanteenPlan } from '../types/canteen-plan.js'
+import { SimpleSiteOptions } from '../types/options.js'
 
 // CONSTANTS
 

--- a/src/simplesite/match-line-name.ts
+++ b/src/simplesite/match-line-name.ts
@@ -1,4 +1,4 @@
-import canteens from '../../data/canteens.json'
+import { canteens } from '../data.js'
 
 // CONSTANTS
 

--- a/src/simplesite/parse-datestamp.ts
+++ b/src/simplesite/parse-datestamp.ts
@@ -1,4 +1,4 @@
-import { DateSpec } from '../types/date-spec'
+import { DateSpec } from '../types/date-spec.js'
 
 // CONSTANTS
 

--- a/src/simplesite/parse-name-and-additives.ts
+++ b/src/simplesite/parse-name-and-additives.ts
@@ -1,4 +1,4 @@
-import { mergeWhitespace } from '../util/merge-whitespace'
+import { mergeWhitespace } from '../util/merge-whitespace.js'
 
 // CONSTANTS
 

--- a/src/simplesite/simplesite-date-util.ts
+++ b/src/simplesite/simplesite-date-util.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { datelike } from '../types/date-spec'
+import { datelike } from '../types/date-spec.js'
 
 /**
  * Get the current calendar week.

--- a/src/simplesite/simplesite-parse.ts
+++ b/src/simplesite/simplesite-parse.ts
@@ -1,13 +1,10 @@
 import cheerio, { Cheerio, CheerioAPI, Element } from 'cheerio'
-
-import { mergeWhitespace } from '../util/merge-whitespace'
-
-import { parseDatestamp } from './parse-datestamp'
-import { parseClassifiers } from './parse-classifiers'
-import { parseNameAndAdditives } from './parse-name-and-additives'
-
-import { matchLineName } from './match-line-name'
-import { CanteenLine, CanteenMeal, CanteenPlan } from '../types/canteen-plan'
+import { mergeWhitespace } from '../util/merge-whitespace.js'
+import { parseDatestamp } from './parse-datestamp.js'
+import { parseClassifiers } from './parse-classifiers.js'
+import { parseNameAndAdditives } from './parse-name-and-additives.js'
+import { matchLineName } from './match-line-name.js'
+import { CanteenLine, CanteenMeal, CanteenPlan } from '../types/canteen-plan.js'
 
 // METHODS
 

--- a/src/types/canteen-plan.ts
+++ b/src/types/canteen-plan.ts
@@ -1,4 +1,4 @@
-import { DateSpec } from './date-spec'
+import { DateSpec } from './date-spec.js'
 
 /**
  * An object containing data about a specific meal.

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import { datelike } from './date-spec'
+import { datelike } from './date-spec.js'
 
 /**
  * Fetcher options object. Depending on the value of source, additional options might be available.

--- a/test/cookies/request-session-cookie.test.ts
+++ b/test/cookies/request-session-cookie.test.ts
@@ -1,5 +1,5 @@
-import { requestSessionCookie } from '../../src/cookies/request-session-cookie'
-import { LazyMockAdapter } from '../helper-lazymockadapter'
+import { requestSessionCookie } from '../../src/cookies/request-session-cookie.js'
+import { LazyMockAdapter } from '../helper-lazymockadapter.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/data/canteens.test.ts
+++ b/test/data/canteens.test.ts
@@ -1,6 +1,6 @@
-import canteens from '../../data/canteens.json'
-import { isTrimmed } from '../helper-is-trimmed'
-import { checkDuplicates } from '../helper-check-duplicates'
+import { canteens } from '../../src/data.js'
+import { isTrimmed } from '../helper-is-trimmed.js'
+import { checkDuplicates } from '../helper-check-duplicates.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/data/legend.test.ts
+++ b/test/data/legend.test.ts
@@ -1,6 +1,6 @@
-import legend from '../../data/legend.json'
-import { isTrimmed } from '../helper-is-trimmed'
-import { checkDuplicates } from '../helper-check-duplicates'
+import { legend } from '../../src/data.js'
+import { isTrimmed } from '../helper-is-trimmed.js'
+import { checkDuplicates } from '../helper-check-duplicates.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/jsonapi/build-canteen-lookup.test.ts
+++ b/test/jsonapi/build-canteen-lookup.test.ts
@@ -1,4 +1,4 @@
-import { buildCanteenLookup } from '../../src/jsonapi/build-canteen-lookup'
+import { buildCanteenLookup } from '../../src/jsonapi/build-canteen-lookup.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/jsonapi/jsonapi-parse-metadata.test.ts
+++ b/test/jsonapi/jsonapi-parse-metadata.test.ts
@@ -1,4 +1,4 @@
-import { parseMetadata } from '../../src/jsonapi/jsonapi-parse-metadata'
+import { parseMetadata } from '../../src/jsonapi/jsonapi-parse-metadata.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/jsonapi/jsonapi-parse-plans.test.ts
+++ b/test/jsonapi/jsonapi-parse-plans.test.ts
@@ -1,4 +1,4 @@
-import { parsePlans } from '../../src/jsonapi/jsonapi-parse-plans'
+import { parsePlans } from '../../src/jsonapi/jsonapi-parse-plans.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/jsonapi/jsonapi-request.test.ts
+++ b/test/jsonapi/jsonapi-request.test.ts
@@ -1,5 +1,5 @@
-import { request, METADATA_ENDPOINT, PLANS_ENDPOINT } from '../../src/jsonapi/jsonapi-request'
-import { LazyMockAdapter } from '../helper-lazymockadapter'
+import { request, METADATA_ENDPOINT, PLANS_ENDPOINT } from '../../src/jsonapi/jsonapi-request.js'
+import { LazyMockAdapter } from '../helper-lazymockadapter.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/match-line-name.test.ts
+++ b/test/simplesite/match-line-name.test.ts
@@ -1,4 +1,4 @@
-import { matchLineName } from '../../src/simplesite/match-line-name'
+import { matchLineName } from '../../src/simplesite/match-line-name.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-classifiers.test.ts
+++ b/test/simplesite/parse-classifiers.test.ts
@@ -1,4 +1,4 @@
-import { parseClassifiers } from '../../src/simplesite/parse-classifiers'
+import { parseClassifiers } from '../../src/simplesite/parse-classifiers.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-datestamp.test.ts
+++ b/test/simplesite/parse-datestamp.test.ts
@@ -1,4 +1,4 @@
-import { parseDatestamp } from '../../src/simplesite/parse-datestamp'
+import { parseDatestamp } from '../../src/simplesite/parse-datestamp.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/parse-name-and-additives.test.ts
+++ b/test/simplesite/parse-name-and-additives.test.ts
@@ -1,4 +1,4 @@
-import { parseNameAndAdditives } from '../../src/simplesite/parse-name-and-additives'
+import { parseNameAndAdditives } from '../../src/simplesite/parse-name-and-additives.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/simplesite-date-util.test.ts
+++ b/test/simplesite/simplesite-date-util.test.ts
@@ -1,4 +1,4 @@
-import * as dateUtil from '../../src/simplesite/simplesite-date-util'
+import * as dateUtil from '../../src/simplesite/simplesite-date-util.js'
 import moment from 'moment'
 
 import chai, { expect } from 'chai'

--- a/test/simplesite/simplesite-parse.test.ts
+++ b/test/simplesite/simplesite-parse.test.ts
@@ -1,4 +1,4 @@
-import { parse } from '../../src/simplesite/simplesite-parse'
+import { parse } from '../../src/simplesite/simplesite-parse.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/simplesite/simplesite-request.test.ts
+++ b/test/simplesite/simplesite-request.test.ts
@@ -1,5 +1,5 @@
-import { request } from '../../src/simplesite/simplesite-request'
-import { LazyMockAdapter } from '../helper-lazymockadapter'
+import { request } from '../../src/simplesite/simplesite-request.js'
+import { LazyMockAdapter } from '../helper-lazymockadapter.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/test/util/merge-whitespace.test.ts
+++ b/test/util/merge-whitespace.test.ts
@@ -1,4 +1,4 @@
-import { mergeWhitespace } from '../../src/util/merge-whitespace'
+import { mergeWhitespace } from '../../src/util/merge-whitespace.js'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "strict": true,
     "declaration": true,
     "outDir": "./dist"


### PR DESCRIPTION
This project is now packaged as ESM instead of CommonJS. At least
version 14.13.1 of Node.js is required. Most of the changes are adding
file extensions to the imports. Additionally, a helper had to be added
for importing the JSON data files.