### PR TITLE
refactor: Move all source code into 'src/'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "lint": "eslint --ignore-path .gitignore . && tsc --noEmit",
-    "lint-fix": "eslint --fix --ignore-path .gitignore . && tsc --noEmit",
+    "lint": "tsc --noEmit && eslint --ignore-path .gitignore .",
+    "lint-fix": "tsc --noEmit && eslint --fix --ignore-path .gitignore .",
     "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\"",
     "coverage": "c8 --reporter=lcov --reporter=text --all --include src --exclude \"src/types/\" npm test",
     "prepack": "npm run build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { fetch as fetchSimpleSite } from './src/simplesite/index.js'
-import { fetch as fetchJson } from './src/jsonapi/index.js'
-import { JsonApiOptions, Options, SimpleSiteOptions } from './src/types/options.js'
-import { CanteenPlan } from './src/types/canteen-plan.js'
+import { fetch as fetchSimpleSite } from './simplesite/index.js'
+import { fetch as fetchJson } from './jsonapi/index.js'
+import { JsonApiOptions, Options, SimpleSiteOptions } from './types/options.js'
+import { CanteenPlan } from './types/canteen-plan.js'
 
 // HELPER FUNCTIONS
 
@@ -70,15 +70,15 @@ export async function fetchMensa (source: 'simplesite' | 'jsonapi' = 'simplesite
 }
 
 // re-export session cookie function
-export { requestSessionCookie } from './src/cookies/request-session-cookie.js'
+export { requestSessionCookie } from './cookies/request-session-cookie.js'
 
 // re-export types
-export { Line, Canteen } from './src/types/canteen.js'
-export { LegendItem } from './src/types/legend.js'
-export { CanteenPlan, CanteenLine, CanteenMeal } from './src/types/canteen-plan.js'
-export { DateSpec, datelike } from './src/types/date-spec.js'
-export { Options, SimpleSiteOptions, JsonApiOptions, AuthConfig } from './src/types/options.js'
+export { Line, Canteen } from './types/canteen.js'
+export { LegendItem } from './types/legend.js'
+export { CanteenPlan, CanteenLine, CanteenMeal } from './types/canteen-plan.js'
+export { DateSpec, datelike } from './types/date-spec.js'
+export { Options, SimpleSiteOptions, JsonApiOptions, AuthConfig } from './types/options.js'
 
 // re-export data
-export { canteens } from './src/data/canteens.js'
-export { legend } from './src/data/legend.js'
+export { canteens } from './data/canteens.js'
+export { legend } from './data/legend.js'

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "dist",
-    "node_modules"
+  "include": [
+    "src",
+    "test"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,7 @@
     "declaration": true,
     "outDir": "./dist"
   },
-  "exclude": [
-    "test",
-    "dist",
-    "node_modules"
+  "include": [
+    "src"
   ]
 }


### PR DESCRIPTION
Now the index.ts doesn't live among the configuration files, and is
instead treated as a source file (which it has always been, of course).