### PR TITLE
fix(jsonapi): Update endpoint URLs to fix infinite redirect errors

### DIFF
--- a/src/jsonapi/jsonapi-request.ts
+++ b/src/jsonapi/jsonapi-request.ts
@@ -6,12 +6,12 @@ import { AuthConfig } from '../types/options.js'
 /**
  * URL of the JSON API general endpoint.
  */
-export const METADATA_ENDPOINT = 'https://www.sw-ka.de/json_interface/general/'
+export const METADATA_ENDPOINT = 'https://www.sw-ka.de/en/json_interface/general/'
 
 /**
  * URL of the JSON API canteen endpoint.
  */
-export const PLANS_ENDPOINT = 'https://www.sw-ka.de/json_interface/canteen/'
+export const PLANS_ENDPOINT = 'https://www.sw-ka.de/en/json_interface/canteen/'
 
 /**
  * Conservative request timeout in milliseconds.

--- a/test/jsonapi/jsonapi-request.test.ts
+++ b/test/jsonapi/jsonapi-request.test.ts
@@ -24,7 +24,7 @@ describe('jsonapi/jsonapi-request', function () {
   describe('with #METADATA_ENDPOINT', function () {
     it('sends request as expected', function () {
       lazyMock.get().onAny().replyOnce(config => {
-        expect(config.url).to.equal('https://www.sw-ka.de/json_interface/general/')
+        expect(config.url).to.equal('https://www.sw-ka.de/en/json_interface/general/')
         expect(config.method).to.equal('get')
         expect(config.auth).to.deep.equal({
           username: 'a',
@@ -54,7 +54,7 @@ describe('jsonapi/jsonapi-request', function () {
   describe('with #PLANS_ENDPOINT', function () {
     it('sends request as expected', function () {
       lazyMock.get().onAny().replyOnce(config => {
-        expect(config.url).to.equal('https://www.sw-ka.de/json_interface/canteen/')
+        expect(config.url).to.equal('https://www.sw-ka.de/en/json_interface/canteen/')
         expect(config.method).to.equal('get')
         expect(config.auth).to.deep.equal({
           username: 'a',


### PR DESCRIPTION
Due to an update to the SW-KA website, the API redirects appear broken.
'/json_interface/general/' redirects to '/de/json_interface/general/',
which redirects back to '/json_interface/general/'.
Only '/en/json_interface/general/' seems to give immediate results
without further redirects.