### PR TITLE
fix(simplesite): Update URL and page structure after SW-KA redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,11 @@ This is relatively reliable as long as there are no structural changes.
 
 The URL used is the following:
 
-`https://www.sw-ka.de/de/essen/?view=ok&STYLE=popup_plain&c=adenauerring&p=1&kw=49`
+`https://www.sw-ka.de/de/hochschulgastronomie/speiseplan/mensa_adenauerring/?view=ok&STYLE=popup_plain&c=adenauerring&p=1&kw=49`
 
-Here, `adenauerring` is the canteen id and `kw=49` indicates that the plan for
-the 49th calendar week is requested (weeks _probably_ following ISO 8601).
+Here, `adenauerring` (appears twice!) is the canteen id and `kw=49` indicates
+that the plan for the 49th calendar week is requested. The calendar weeks
+likely follow ISO-8601.
 
 Unfortunately, the `p` parameter representing price category (1 for students,
 2 for guests, 3 for employees, 4 for school children) has no effect. This
@@ -396,9 +397,9 @@ It requires authentication, which is why it is not the default source.
 
 Endpoints:
 
-1. `https://www.sw-ka.de/json_interface/general/` - used for obtaining
+1. `https://www.sw-ka.de/en/json_interface/general/` - used for obtaining
   up-to-date canteen and line names
-2. `https://www.sw-ka.de/json_interface/canteen/` - used for obtaining the meal
+2. `https://www.sw-ka.de/en/json_interface/canteen/` - used for obtaining the meal
   plans
 
 There are no (known) parameters. The API returns all data from the beginning of

--- a/src/simplesite/simplesite-parse.ts
+++ b/src/simplesite/simplesite-parse.ts
@@ -126,15 +126,16 @@ function parseMeal ($: CheerioAPI, $row: Cheerio<Element>): CanteenMeal | undefi
  */
 export function parse (html: string, canteenId: string, referenceDate: Date): CanteenPlan[] {
   const $ = cheerio.load(html)
-  const $titles = $('#platocontent > h1')
+  const $titles = $('#platocontent .article-div > h1')
 
-  // canteen name is stored in first <h1>
+  // The canteen name is stored in the first <h1>.
   const canteenName = $titles.first().text()
 
-  // remaining <h1> elements store plan dates
-  return $titles.slice(1, 6).map((_, el) => {
+  // The remaining <h1> elements may contain plan dates, but also potentially other things.
+  return $titles.slice(1).map((_, el) => {
     const dateElement = $(el)
     const date = parseDatestamp(dateElement.text(), referenceDate)
+    // This <h1> may have been some other meaningless title, and not a date.
     if (date != null) {
       return {
         id: canteenId,

--- a/src/simplesite/simplesite-request.ts
+++ b/src/simplesite/simplesite-request.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestHeaders } from 'axios'
 /**
  * URL of the simplified web view.
  */
-const BASE_URL = 'https://www.sw-ka.de/de/essen/'
+const BASE_URL = 'https://www.sw-ka.de/de/hochschulgastronomie/speiseplan/'
 
 /**
  * Conservative request timeout in milliseconds.
@@ -49,7 +49,7 @@ export async function request (canteenId: string, weekId: string | number, sessi
     headers.Cookie = `platoCMS=${sessionCookie}`
   }
 
-  const response = await axios.get(BASE_URL, {
+  const response = await axios.get(`${BASE_URL}mensa_${canteenId}/`, {
     params: {
       STYLE: 'popup_plain',
       view: 'ok',

--- a/test/simplesite/simplesite-request.test.ts
+++ b/test/simplesite/simplesite-request.test.ts
@@ -11,7 +11,7 @@ describe('simplesite/simplesite-request', function () {
 
   it('sends request as expected', function () {
     lazyMock.get().onAny().replyOnce(config => {
-      expect(config.url).to.equal('https://www.sw-ka.de/de/essen/')
+      expect(config.url).to.equal('https://www.sw-ka.de/de/hochschulgastronomie/speiseplan/mensa_test-canteen/')
       expect(config.method).to.equal('get')
       expect(config.params).to.deep.equal({
         STYLE: 'popup_plain',


### PR DESCRIPTION
The website received a fundamental layout change and some URLs were
updated, too. This patch fixes simplesite-request and simplesite-parse
to work again under these new conditions.