### PR TITLE
feat: Perform line name matching case-insensitively

### DIFF
--- a/src/data/canteens.ts
+++ b/src/data/canteens.ts
@@ -138,10 +138,7 @@ export const canteens: Canteen[] = [
       },
       {
         id: 'curryqueen',
-        name: '[Kœri]werk',
-        alternativeNames: [
-          '[kœri]werk'
-        ]
+        name: '[Kœri]werk'
       }
     ]
   },
@@ -209,10 +206,7 @@ export const canteens: Canteen[] = [
       },
       {
         id: 'curryqueen',
-        name: '[Kœri]werk',
-        alternativeNames: [
-          '[kœri]werk'
-        ]
+        name: '[Kœri]werk'
       }
     ]
   },

--- a/src/simplesite/match-line-name.ts
+++ b/src/simplesite/match-line-name.ts
@@ -3,6 +3,16 @@ import { canteens } from '../data/canteens.js'
 // CONSTANTS
 
 /**
+ * Normalize the given canteen name for indexing into the lookup Map.
+ *
+ * @param name The human-readable name.
+ * @returns The normalized name, potentially less pretty, but also with less entropy.
+ */
+function normalizeLineNameForLookup (name: string): string {
+  return name.trim().toLocaleLowerCase(['de-DE', 'en-US'])
+}
+
+/**
  * A Map from canteen ids to Maps from line names to line ids.
  * I.e. schema: (canteenId => (lineName => lineId))
  */
@@ -13,7 +23,7 @@ const LINE_IDS_MAPPING: Map<string, Map<string, string>> = (() => {
     const lineMapping = new Map()
     for (const line of canteen.lines) {
       const allNames = [line.name, ...(line.alternativeNames ?? [])]
-      allNames.forEach(name => lineMapping.set(name, line.id))
+      allNames.forEach(name => lineMapping.set(normalizeLineNameForLookup(name), line.id))
     }
     mapping.set(canteen.id, lineMapping)
   }
@@ -38,5 +48,5 @@ export function matchLineName (canteenId: string, name: string): string | undefi
   if (lineNameToIdMap == null) {
     return undefined
   }
-  return lineNameToIdMap.get(name.trim())
+  return lineNameToIdMap.get(normalizeLineNameForLookup(name))
 }

--- a/test/data/canteens.test.ts
+++ b/test/data/canteens.test.ts
@@ -56,12 +56,14 @@ describe('data/canteens', function () {
     }
   })
 
-  it('does not have duplicate line names in canteens', function () {
+  it('does not have duplicate line names in canteens (case-insensitive)', function () {
     for (const entry of canteens) {
       const allNames: string[] = []
       for (const line of entry.lines) {
-        allNames.push(line.name)
-        allNames.push(...(line.alternativeNames ?? []))
+        allNames.push(line.name.toLocaleLowerCase(['de-DE', 'en-US']))
+        if (line.alternativeNames != null) {
+          allNames.push(...line.alternativeNames.map(name => name.toLocaleLowerCase(['de-DE', 'en-US'])))
+        }
       }
       checkDuplicates(expect, allNames, name => name)
     }

--- a/test/simplesite/match-line-name.test.ts
+++ b/test/simplesite/match-line-name.test.ts
@@ -36,4 +36,10 @@ describe('simplesite/match-line-name', function () {
   it('matches alternative names', function () {
     expect(matchLineName('adenauerring', '[kœri]werk 11-14 Uhr')).to.equal('aktion')
   })
+
+  it('matches case-insensitively', function () {
+    expect(matchLineName('adenauerring', 'linie 1')).to.equal('l1')
+    expect(matchLineName('adenauerring', 'LinIE 1')).to.equal('l1')
+    expect(matchLineName('adenauerring', '[kœri]werk 11-14 UHR')).to.equal('aktion')
+  })
 })


### PR DESCRIPTION
Line names no longer care about upper-/lowercase letters. This solves a
problem where currently, "Linie 2 vegane Linie" is part of our set of
line names but the name was recently changed to "Linie 2 Vegane Linie"
which couldn't be matched (until now!).

I could have chosen to add the differently-cased name to the set of line
names but this is probably a better solution especially considering
future impact.