### PR TITLE
chore: Remove ts-node/register from test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
-    "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\"",
+    "test": "mocha --recursive \"test/**/*.test.*\"",
     "coverage": "c8 --reporter=lcov --reporter=text --all --include src --exclude \"src/types/\" npm test",
     "prepack": "npm run build"
   },


### PR DESCRIPTION
The CommonJS variant of ts-node is obsolete since this package was switched to ESM. We've been using `ts-node/esm` for a while via `.mocharc.cjs`.