### PR TITLE
fix: Do not rely on .article-div

### DIFF
--- a/src/simplesite/simplesite-parse.ts
+++ b/src/simplesite/simplesite-parse.ts
@@ -122,7 +122,7 @@ function parseMeal ($: CheerioAPI, $row: Cheerio<Element>): CanteenMeal | undefi
  */
 export function parse (html: string, canteenId: string, referenceDate: Date): CanteenPlan[] {
   const $ = load(html)
-  const $titles = $('#platocontent .article-div > h1')
+  const $titles = $('#platocontent h1')
 
   // The canteen name is stored in the first <h1>.
   const canteenName = $titles.first().text()

--- a/test/simplesite/simplesite-parse.test.ts
+++ b/test/simplesite/simplesite-parse.test.ts
@@ -20,19 +20,15 @@ function wrapContent (canteenName: string, content: string): string {
             <tr>
               <td>
                 <div id="platocontent" class="platocontent">
-                  <article>
-                    <div class="article-div">
-                      <h1 class="mensa_fullname">${canteenName}</h1>
-                      <h1>${canteenName}</h1>
-                      Preise für Studenten
-                      <p><style></style></p>
-                      ${content}
-                      <b>Legende</b><br>
-                      (1) mit Farbstoff<br>
-                      <b>Freiwillige Angaben</b><br>
-                      [R] enthält Rindfleisch
-                    </div>
-                  </article>
+                  <h1 class="mensa_fullname">${canteenName}</h1>
+                  <h1>${canteenName}</h1>
+                  Preise für Studierende
+                  <p><style></style></p>
+                  ${content}
+                  <b>Legende</b><br>
+                  (1) mit Farbstoff<br>
+                  <b>Freiwillige Angaben</b><br>
+                  [R] enthält Rindfleisch
                 </div>
               </td>
               <td>


### PR DESCRIPTION
SW-KA have pushed an update where some wrapper elements are no longer present on the page. This breaks 'simplesite' plan parsing. By simplifying the DOM selector, this patch restores it to a working condition while keeping backwards-compatibility.